### PR TITLE
Update README and url

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -1,6 +1,6 @@
 project_name: NengoLMU
 pkg_name: lmu
-repo_name: abr/lmu
+repo_name: nengo/lmu
 description: Legendre Memory Units
 
 copyright_start: 2019

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Filing issues
 If you find a bug in NengoLMU,
 or think that a certain feature is missing,
 please consider
-`filing an issue <https://github.com/abr/lmu/issues>`_!
+`filing an issue <https://github.com/nengo/lmu/issues>`_!
 Please search the currently open issues first
 to see if your bug or feature request already exists.
 If so, feel free to add a comment to the issue

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -4,7 +4,7 @@
 NengoLMU contributors
 *********************
 
-See https://github.com/abr/lmu/graphs/contributors
+See https://github.com/nengo/lmu/graphs/contributors
 for a list of the people who have committed to NengoLMU.
 Thank you for your contributions!
 

--- a/README.rst
+++ b/README.rst
@@ -3,34 +3,61 @@ Legendre Memory Units: Continuous-Time Representation in Recurrent Neural Networ
 
 `Paper <https://papers.nips.cc/paper/9689-legendre-memory-units-continuous-time-representation-in-recurrent-neural-networks.pdf>`_
 
-NengoLMU is a python software library containing various implementations of the Legendre Memory Unit (LMU). The LMU is a novel memory cell for recurrent neural networks that dynamically maintains information across long windows of time using relatively few resources. It has been shown to perform as well as standard LSTM or other RNN-based models in a variety of tasks, generally with fewer internal parameters (see `this paper <https://papers.nips.cc/paper/9689-legendre-memory-units-continuous-time-representation-in-recurrent-neural-networks.pdf>`_ for more details). For the Permuted Sequential MNIST (psMNIST) task in particular, it has been demonstrated to outperform the current state-of-the-art results. See the note below for instructions on how to get access to this model.
+This is a python software library containing various implementations of the
+Legendre Memory Unit (LMU). The LMU is a novel memory cell for recurrent neural
+networks that dynamically maintains information across long windows of time using
+relatively few resources. It has been shown to perform as well as standard LSTM or
+other RNN-based models in a variety of tasks, generally with fewer internal parameters
+(see `this paper
+<https://papers.nips.cc/paper/9689-legendre-memory-units-continuous-time-representation-in-recurrent-neural-networks.pdf>`_ for more details). For the Permuted Sequential MNIST (psMNIST) task in particular, it has been demonstrated to outperform the current state-of-the-art results. See the note below for instructions on how to get access to this model.
 
-The LMU is mathematically derived to orthogonalize its continuous-time history – doing so by solving *d* coupled ordinary differential equations (ODEs), whose phase space linearly maps onto sliding windows of time via the Legendre polynomials up to degree *d* − 1 (the example for *d* = 12 is shown below).
+The LMU is mathematically derived to orthogonalize its continuous-time history – doing
+so by solving *d* coupled ordinary differential equations (ODEs), whose phase space
+linearly maps onto sliding windows of time via the Legendre polynomials up to degree
+*d* − 1 (the example for *d* = 12 is shown below).
 
 .. image:: https://i.imgur.com/Uvl6tj5.png
    :target: https://i.imgur.com/Uvl6tj5.png
    :alt: Legendre polynomials
 
-A single LMU cell expresses the following computational graph, which takes in an input signal, **x**, and couples a optimal linear memory, **m**, with a nonlinear hidden state, **h**. By default, this coupling is trained via backpropagation, while the dynamics of the memory remain fixed.
+A single LMU cell expresses the following computational graph, which takes in an input
+signal, **x**, and couples a optimal linear memory, **m**, with a nonlinear hidden
+state, **h**. By default, this coupling is trained via backpropagation, while the
+dynamics of the memory remain fixed.
 
 .. image:: https://i.imgur.com/IJGUVg6.png
    :target: https://i.imgur.com/IJGUVg6.png
    :alt: Computational graph
 
-The discretized **A** and **B** matrices are initialized according to the LMU 's mathematical derivation with respect to some chosen window length, **θ**. Backpropagation can be used to learn this time-scale, or fine-tune **A** and **B**, if necessary.
+The discretized **A** and **B** matrices are initialized according to the LMU's
+mathematical derivation with respect to some chosen window length, **θ**.
+Backpropagation can be used to learn this time-scale, or fine-tune **A** and **B**,
+if necessary.
 
-Both the kernels, **W**, and the encoders, **e**, are learned. Intuitively, the kernels learn to compute nonlinear functions across the memory, while the encoders learn to project the relevant information into the memory (see `paper <https://papers.nips.cc/paper/9689-legendre-memory-units-continuous-time-representation-in-recurrent-neural-networks.pdf>`_ for details).
+Both the kernels, **W**, and the encoders, **e**, are learned. Intuitively, the kernels
+learn to compute nonlinear functions across the memory, while the encoders learn to
+project the relevant information into the memory (see `paper
+<https://papers.nips.cc/paper/9689-legendre-memory-units-continuous-time-representation-in-recurrent-neural-networks.pdf>`_ for details).
 
 .. note::
 
-   The ``paper`` branch in the ``lmu`` GitHub repository includes a pre-trained Keras/TensorFlow model, located at ``models/psMNIST-standard.hdf5``, which obtains the current best-known psMNIST result (using an RNN) of **97.15%**. Note that the network is using fewer internal state-variables and neurons than there are pixels in the input sequence. To reproduce the results from `this paper <https://papers.nips.cc/paper/9689-legendre-memory-units-continuous-time-representation-in-recurrent-neural-networks.pdf>`_, run the notebooks in the ``experiments`` directory within the ``paper`` branch.
+   The ``paper`` branch in the ``lmu`` GitHub repository includes a pre-trained
+   Keras/TensorFlow model, located at ``models/psMNIST-standard.hdf5``, which obtains
+   a psMNIST result of **97.15%**. Note that the network is using fewer internal
+   state-variables and neurons than there are pixels in the input sequence.
+   To reproduce the results from `this paper
+   <https://papers.nips.cc/paper/9689-legendre-memory-units-continuous-time-representation-in-recurrent-neural-networks.pdf>`_,
+   run the notebooks in the ``experiments`` directory within the ``paper`` branch.
 
 Nengo Examples
 --------------
 
-* `LMUs in Nengo (with online learning) <https://www.nengo.ai/nengo/examples/learning/lmu.html>`_
-* `Spiking LMUs in Nengo Loihi (with online learning) <https://www.nengo.ai/nengo-loihi/examples/lmu.html>`_
-* `LMUs in NengoDL (reproducing SotA on psMNIST) <https://www.nengo.ai/nengo-dl/examples/lmu.html>`_
+* `LMUs in Nengo (with online learning)
+  <https://www.nengo.ai/nengo/examples/learning/lmu.html>`_
+* `Spiking LMUs in Nengo Loihi (with online learning)
+  <https://www.nengo.ai/nengo-loihi/examples/lmu.html>`_
+* `LMUs in NengoDL (reproducing SotA on psMNIST)
+  <https://www.nengo.ai/nengo-dl/examples/lmu.html>`_
 
 Citation
 --------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ autoautosummary_change_modules = {
 
 # -- nengo_sphinx_theme.ext.sourcelinks
 sourcelinks_module = "lmu"
-sourcelinks_url = "https://github.com/abr/lmu"
+sourcelinks_url = "https://github.com/nengo/lmu"
 
 # -- sphinx
 nitpicky = True

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     author="Applied Brain Research",
     author_email="info@appliedbrainresearch.com",
     packages=find_packages(),
-    url="https://www.appliedbrainresearch.com/lmu",
+    url="https://www.nengo.ai/lmu",
     include_package_data=False,
     license="Free for non-commercial use",
     description="Legendre Memory Units",


### PR DESCRIPTION
Moved the repo to the Nengo org, so updating URLs to match (we'll also add redirects from the old URLs to these updated ones).